### PR TITLE
feature: specify patch version of image

### DIFF
--- a/0.10.38/onbuild/Dockerfile
+++ b/0.10.38/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10-onbuild
+FROM node:0.10.38-onbuild
 
 RUN npm install -g nodemon
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# node-development
-Node development using nodemon
+# Node Development
+Creates docker containers based on the official Docker version of [Node.js](https://registry.hub.docker.com/_/node). On top of those images it installs `nodemon` and changes the default command to `nodemon .`
+
+## Supported tags and respective `Dockerfile` links
+- `0.10-onbuild` [(0.10/onbuild/Dockerfile)](https://github.com/School-Improvement-Network/node-development/blob/master/0.10/onbuild/Dockerfile)
+- `0.12-onbuild` [(0.12/onbuild/Dockerfile)](https://github.com/School-Improvement-Network/node-development/blob/master/0.12/onbuild/Dockerfile)


### PR DESCRIPTION
@fakewaffle @gideonairex @yamii Should we be specifying to the patch version? e.g. 0.10.38-onbuild, because our 0.10-onbuild won't be updated if/when they move to node 0.10.39. This means that our development could come out of sync with the production containers by a few patch versions.
